### PR TITLE
CHANGE: replace build-id link by pipelines or job page

### DIFF
--- a/src/components/Builds.vue
+++ b/src/components/Builds.vue
@@ -30,7 +30,7 @@
           </div>
           <div class="extra content">
             <span class="left floated hashtag build-id">
-              <a target="_blank" v-bind:href="build.link_to_branch">
+              <a target="_blank" v-bind:href="build.link_to_build">
               <i class="hashtag icon"></i>
                 {{ build.id}}
               </a>

--- a/src/main.js
+++ b/src/main.js
@@ -350,6 +350,12 @@ var root = new Vue({
     getLinkToBranch (project, repo) {
       return `${this.gitlabciProtocol}://${this.gitlab}/${project.path_with_namespace}/tree/${repo.branch}`
     },
+    getLinkToPipeline (project, repo, buildId) {
+      return `${this.gitlabciProtocol}://${this.gitlab}/${project.path_with_namespace}/pipelines/${buildId}`
+    },
+    getLinkToJob (project, repo, buildId) {
+      return `${this.gitlabciProtocol}://${this.gitlab}/${project.path_with_namespace}/-/jobs/${buildId}`
+    },
     loadBuilds (onBuilds, data, repo, project, tag) {
       let updated = false
 
@@ -383,6 +389,7 @@ var root = new Vue({
           b.tag_name = tag && tag.name
           b.namespace_name = project.namespace.full_path
           b.link_to_branch = this.getLinkToBranch(project, repo)
+          b.link_to_build = this.getLinkToJob(project, repo, build.id)
           b.description = repo.description
         }
       }
@@ -402,7 +409,8 @@ var root = new Vue({
           branch: repo.branch,
           tag_name: tag && tag.name,
           namespace_name: project.namespace.full_path,
-          link_to_branch: this.getLinkToBranch(project, repo)
+          link_to_branch: this.getLinkToBranch(project, repo),
+          link_to_build : this.getLinkToJob(project, repo, build.id)
         }
         onBuilds.push(buildToAdd)
       }
@@ -450,6 +458,7 @@ var root = new Vue({
                     build.tag_name = tag && tag.name
                     build.namespace_name = project.namespace.full_path
                     build.link_to_branch = this.getLinkToBranch(project, repo)
+                    build.link_to_build = this.getLinkToPipeline(project, repo, lastPipeline.id)
                   }
                 })
                 if (!updated) {
@@ -467,6 +476,7 @@ var root = new Vue({
                   buildToAdd.tag_name = tag && tag.name
                   buildToAdd.namespace_name = project.namespace.full_path
                   buildToAdd.link_to_branch = this.getLinkToBranch(project, repo)
+                  buildToAdd.link_to_build = this.getLinkToPipeline(project, repo, lastPipeline.id)
                   this.onBuilds.push(buildToAdd)
                 }
               })

--- a/test/unit/specs/main.spec.js
+++ b/test/unit/specs/main.spec.js
@@ -254,5 +254,49 @@ describe('main.js', () => {
       const url = vmMethods.getLinkToBranch(mockedProject, mockedRepo)
       expect(url).toEqual('gitlabciProtocol://gitlab/n1/p1/tree/b1')
     })
+    it('Should create pipeline link', () => {
+      const mockedProject = {
+        name: 'p1',
+        namespace: {
+          name: 'n1'
+        },
+        path_with_namespace: 'n1/p1'
+      }
+      const mockedRepo = {
+        branch: 'b1'
+      }
+      const mockedBuild = {
+        id: 1,
+        status: 'running',
+        started_at: '2017-10-06T17:41:41.000Z',
+        commit: {
+          author_name: 'Author'
+        }
+      }
+      const url = vmMethods.getLinkToPipeline(mockedProject, mockedRepo, mockedBuild.id)
+      expect(url).toEqual('gitlabciProtocol://gitlab/n1/p1/pipelines/1')
+    })
+    it('Should create job link', () => {
+      const mockedProject = {
+        name: 'p1',
+        namespace: {
+          name: 'n1'
+        },
+        path_with_namespace: 'n1/p1'
+      }
+      const mockedRepo = {
+        branch: 'b1'
+      }
+      const mockedBuild = {
+        id: 1,
+        status: 'running',
+        started_at: '2017-10-06T17:41:41.000Z',
+        commit: {
+          author_name: 'Author'
+        }
+      }
+      const url = vmMethods.getLinkToJob(mockedProject, mockedRepo, mockedBuild.id)
+      expect(url).toEqual('gitlabciProtocol://gitlab/n1/p1/-/jobs/1')
+    })
   })
 })


### PR DESCRIPTION
Hi!

I changed the link of the last build id (bottom left) so it will link to the pipeline page (gitlabciProtocol://gitlab/n1/p1/pipelines/x) or the job page (gitlabciProtocol://gitlab/n1/p1/-/jobs/1) instead of the branch page. I tested it against apiVersion=4 & apiVersion=3.

Thank you for this awesome project it's perfect to monitor my deployments!

Hope you find this PR useful ;)
