### PR TITLE
Handle list of tag objects instead of tag version strings

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,5 @@
-build
 config
 mocked_gitlab
-src
 test
 .babelrc
 .editorconfig

--- a/src/App.vue
+++ b/src/App.vue
@@ -430,8 +430,12 @@ body {
   box-shadow: none !important;
 }
 
+.ui.card, .ui.cards>.card.manual {
+  background-color: #6ac19f;
+}
+
 .ui.card, .ui.cards>.card.success {
-  background-color: #00AD68;
+  background-color: #00bf4f;
 }
 
 .ui.card, .ui.cards>.card.failed {

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -30,8 +30,12 @@ body {
   box-shadow: none !important;
 }
 
+.ui.card, .ui.cards>.card.manual {
+  background-color: #6ac19f;
+}
+
 .ui.card, .ui.cards>.card.success {
-  background-color: #00AD68;
+  background-color: #00bf4f;
 }
 
 .ui.card, .ui.cards>.card.failed {
@@ -42,10 +46,10 @@ body {
   background-color: #e75e40;
 }
 
-.ui.card, .ui.cards>.card.running{
+.ui.card, .ui.cards>.card.running {
   background-color: #FFB541;
 }
 
-.ui.card, .ui.cards>.card.canceled{
+.ui.card, .ui.cards>.card.canceled {
   background-color: #aaaaaa;
 }

--- a/src/components/Builds.vue
+++ b/src/components/Builds.vue
@@ -10,15 +10,19 @@
           <div class="content">
             <h3 v-if="build.description" class="ui header">{{ build.description }}</h3>
             <a target="_blank" v-bind:href="build.link_to_branch">
-              <h4 class="header project-name">
+              <h3 class="header project-name">
                 {{ build.project }} ({{ build.branch }})
-              </h4>
+              </h3>
             </a>
             <div class="meta">{{ build.namespace_name }}</div>
-            <div v-if="!isSuccessCard(build)" class="description">
+            <b>Commit:</b>
+            <div class="description">
               {{ build.commit_message }}
             </div>
-            <div v-if="!isSuccessCard(build)"><h4>Blame {{ build.author }}</h4></div>
+            <b>Author:</b>
+            <div class="description">
+              {{ build.author }}
+            </div>
             <div v-if="!isSuccessCard(build) && showVersion(build)" class="ui center floated basic button">
               <h1 style="font-size: 1.5em">{{ build.tag_name }}</h1>
             </div>

--- a/src/components/Painel.vue
+++ b/src/components/Painel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="gcim-painel" class="ui grid card" style="background-color: white">
+  <div id="gcim-painel" class="ui grid card" style="background-color: white; width: 100%">
     <div class="ui row centered" style="padding-bottom: 2em">
       <img class="logo" src="../assets/gitlab-logo.svg" />
     </div>
@@ -9,7 +9,7 @@
     <div v-for="s in localStatus" v-bind:key="s.color" class="ui row">
       <div style="margin: 1em">
         <span style="font-size: 5em">{{ s.total }}</span>
-        <span style="font-size: 1.1em;" v-bind:style="{ color: s.color }">{{ s.text.toUpperCase() }}</span>
+        <b style="font-size: 1.1em;" v-bind:style="{ color: s.color }">{{ s.displayName.toUpperCase() }}</b>
       </div>
     </div>
     <div class="ui row centered">
@@ -58,7 +58,7 @@ export default {
           return ps
         }
         const arr = this.status.filter((s) => {
-          return s.text === ps.text
+          return s.text === ps.status
         })
         if (arr.length > 0) {
           const foundStatus = arr[0]
@@ -81,27 +81,38 @@ export default {
     return {
       painelStatus: [
         {
-          text: 'success',
-          color: '#00ad68',
+          status: 'success',
+          displayName: 'success',
+          color: '#00bf4f',
           total: 0
         },
         {
-          text: 'failed',
+          status: 'manual',
+          displayName: 'Awaiting manual action',
+          color: '#6ac19f',
+          total: 0
+        },
+        {
+          status: 'failed',
+          displayName: 'failed',
           color: '#e7484d',
           total: 0
         },
         {
-          text: 'running',
+          status: 'running',
+          displayName: 'running',
           color: '#2d9fd8',
           total: 0
         },
         {
-          text: 'pending',
+          status: 'pending',
+          displayName: 'pending',
           color: '#ffb541',
           total: 0
         },
         {
-          text: 'canceled',
+          status: 'canceled',
+          displayName: 'canceled',
           color: '#aaaaaa',
           total: 0
         }

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ import {
 import {
   getParameterByName,
   getTopItem,
-  getTopItemByName
+  getTopTagName
 } from '@/utils'
 
 import App from './App'
@@ -432,7 +432,7 @@ var root = new Vue({
         } = data
         getTags(project.id)
           .then((response) => {
-            const tag = getTopItemByName(response.data)
+            const tag = getTopTagName(response.data)
             getPipeline(project.id, lastPipelineId)
               .then((pipeline) => {
                 const lastPipeline = pipeline.data

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,9 +37,14 @@ export const getTopItem = (list) => {
   }) || lastValidEntry
 }
 
-export const getTopItemByName = (list) => {
+export const getTopTagName = (list) => {
   if (!Array.isArray(list) || list.length === 0) {
     return
   }
-  return sort.desc(list).shift()
+
+  var sortedTags = sort.desc(list.map(function (tag) {
+    return tag.name;
+  }));
+  
+  return sortedTags[0]
 }

--- a/test/unit/specs/Painel.spec.js
+++ b/test/unit/specs/Painel.spec.js
@@ -9,14 +9,14 @@ describe('Painel.vue', () => {
   it('should render correct contents', () => {
     const Constructor = Vue.extend(Painel)
     const vm = new Constructor().$mount()
-    expect(vm.localStatus[0].text)
+    expect(vm.localStatus[0].status)
       .toEqual('success')
   })
   it('should return status name: "success"', () => {
     const Constructor = Vue.extend(Painel)
     const vm = new Constructor().$mount()
     vm.status = [{text: 'success'}]
-    expect(vm.localStatus[0].text)
+    expect(vm.localStatus[0].status)
       .toEqual('success')
   })
   it('should compute animation styles por mask, filter and spinner', () => {

--- a/test/unit/specs/utils.spec.js
+++ b/test/unit/specs/utils.spec.js
@@ -1,7 +1,7 @@
 import {
   getParameterByName,
   getTopItem,
-  getTopItemByName
+  getTopTagName
 } from '@/utils'
 
 describe('Utilities', () => {
@@ -53,18 +53,18 @@ describe('Utilities', () => {
     })
   })
   it('Should return latest tag by name', () => {
-    const arr = ['0.9.0', '0.11.0', '1.0.1']
-    const topItem = getTopItemByName(arr)
+    const list = [{name: '0.9.0'},{name: '0.11.0'},{name: '1.0.1'}] 
+    const topItem = getTopTagName(list)
     expect(topItem).toEqual('1.0.1')
   })
   it('Should return latest tag by name with v prefix', () => {
-    const arr = ['v0.9.0', 'v0.11.0', 'v1.0.1']
-    const topItem = getTopItemByName(arr)
+    const list = [{name: 'v0.9.0'},{name: 'v1.0.1'}] 
+    const topItem = getTopTagName(list)
     expect(topItem).toEqual('v1.0.1')
   })
   it('Should return latest tag by name with v prefix and suffixes', () => {
-    const arr = ['v0.9.0-alpha', 'v0.11.0-beta', 'v0.11.0-alpha']
-    const topItem = getTopItemByName(arr)
+    const list = [{name: 'v0.9.0-alpha'},{name: 'v0.11.0-beta'},{name: 'v0.11.0-alpha'}] 
+    const topItem = getTopTagName(list)
     expect(topItem).toEqual('v0.11.0-beta')
   })
 })


### PR DESCRIPTION
People who have seen the error "Cannot read property '0' of null" might have had one or more **tags** in their repos.

The list of tags is actually a list of objects, not strings (maybe this was changed in API v4?). So we need to extract the name properties and pass it as an array to the semver-sort function. 

