### PR TITLE
Handle list of tag objects to retrive the latest tag

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ import {
 import {
   getParameterByName,
   getTopItem,
-  getTopItemByName
+  getTopTagName
 } from '@/utils'
 
 import App from './App'
@@ -432,7 +432,7 @@ var root = new Vue({
         } = data
         getTags(project.id)
           .then((response) => {
-            const tag = getTopItemByName(response.data)
+            const tag = getTopTagName(response.data)
             getPipeline(project.id, lastPipelineId)
               .then((pipeline) => {
                 const lastPipeline = pipeline.data

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,9 +37,14 @@ export const getTopItem = (list) => {
   }) || lastValidEntry
 }
 
-export const getTopItemByName = (list) => {
+export const getTopTagName = (list) => {
   if (!Array.isArray(list) || list.length === 0) {
     return
   }
-  return sort.desc(list).shift()
+
+  var sortedTags = sort.desc(list.map(function (tag) {
+    return tag.name;
+  }));
+  
+  return sortedTags[0]
 }

--- a/test/unit/specs/utils.spec.js
+++ b/test/unit/specs/utils.spec.js
@@ -1,7 +1,7 @@
 import {
   getParameterByName,
   getTopItem,
-  getTopItemByName
+  getTopTagName
 } from '@/utils'
 
 describe('Utilities', () => {
@@ -53,18 +53,18 @@ describe('Utilities', () => {
     })
   })
   it('Should return latest tag by name', () => {
-    const arr = ['0.9.0', '0.11.0', '1.0.1']
-    const topItem = getTopItemByName(arr)
+    const list = [{name: '0.9.0'},{name: '0.11.0'},{name: '1.0.1'}] 
+    const topItem = getTopTagName(list)
     expect(topItem).toEqual('1.0.1')
   })
   it('Should return latest tag by name with v prefix', () => {
-    const arr = ['v0.9.0', 'v0.11.0', 'v1.0.1']
-    const topItem = getTopItemByName(arr)
+    const list = [{name: 'v0.9.0'},{name: 'v1.0.1'}] 
+    const topItem = getTopTagName(list)
     expect(topItem).toEqual('v1.0.1')
   })
   it('Should return latest tag by name with v prefix and suffixes', () => {
-    const arr = ['v0.9.0-alpha', 'v0.11.0-beta', 'v0.11.0-alpha']
-    const topItem = getTopItemByName(arr)
+    const list = [{name: 'v0.9.0-alpha'},{name: 'v0.11.0-beta'},{name: 'v0.11.0-alpha'}] 
+    const topItem = getTopTagName(list)
     expect(topItem).toEqual('v0.11.0-beta')
   })
 })


### PR DESCRIPTION
People who have seen the error "Cannot read property '0' of null" might have had one or more tags in their repos.

The list of tags is actually a list of objects, not strings (maybe this was changed in API v4?). So we need to extract the name properties and pass it as an array to the semver-sort function.